### PR TITLE
Add allow_nil option

### DIFF
--- a/lib/enum_field.rb
+++ b/lib/enum_field.rb
@@ -28,6 +28,7 @@ module EnumField
     # - define the STATUSES constant, which contains the acceptable values
     def enum_field(field, possible_values, options={})
       message = options[:message] || "invalid #{field}"
+      allow_nil = options[:allow_nil]
       const_set field.to_s.pluralize.upcase, possible_values unless const_defined?(field.to_s.pluralize.upcase)
   
       possible_values.each do |current_value|
@@ -37,7 +38,7 @@ module EnumField
         end
       end
   
-      validates_inclusion_of field, :in => possible_values, :message => message
+      validates_inclusion_of field, :in => possible_values, :message => message, :allow_nil => allow_nil
     end
   end
 end


### PR DESCRIPTION
Sometimes it's handy to have a nullable enum field.
